### PR TITLE
Remove comments in meta/main.yml

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,32 +5,8 @@ galaxy_info:
   description: Install and configure gxadmin
   company: Galaxy Project Europe
   issue_tracker_url: https://github.com/galaxyproject/gxadmin/issues
-
-  # Some suggested licenses:
-  # - BSD (default)
-  # - MIT
-  # - GPLv2
-  # - GPLv3
-  # - Apache
-  # - CC-BY
   license: GPLv3
-
   min_ansible_version: "2.4"
-
-  # If this a Container Enabled role, provide the minimum Ansible Container
-  # version.
-  # min_ansible_container_version:
-
-  # Optionally specify the branch Galaxy will use when accessing the GitHub repo
-  # for this role. During role install, if no tags are available, Galaxy will
-  # use this branch. During import Galaxy will access files on this branch. If
-  # Travis integration is configured, only notifications for this branch will be
-  # accepted. Otherwise, in all cases, the repo's default branch (usually
-  # master) will be used.
-  # github_branch:
-
-  # platforms is a list of platforms, and each platform has a name and a list of
-  # versions.
   platforms:
     - name: EL
       versions:
@@ -41,13 +17,4 @@ galaxy_info:
 
   galaxy_tags:
     - system
-    # List tags for your role here, one per line. A tag is a keyword that
-    # describes and categorizes the role. Users find roles by searching for
-    # tags. Be sure to remove the '[]' above, if you add tags to this list.
-    #
-    # NOTE: A tag is limited to a single word comprised of alphanumeric
-    # characters. Maximum 20 tags per role.
-
 dependencies: []
-  # List your role dependencies here, one per line. Be sure to remove the '[]'
-  # above, if you add dependencies to this list.


### PR DESCRIPTION
I think we do not need those generic comments. They are automatically generated by `ansible-galaxy role init` just to help people get started.