### PR TITLE
Make galaxyproject.gxadmin role install its own dependencies

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,7 @@ gxadmin_bin_dir: "/usr/local/bin"
 gxadmin_config_dir: "~/.config"
 gxadmin_create_bin_dir: true
 gxadmin_repo: "https://github.com/galaxyproject/gxadmin.git"
+
+gxadmin_manage_dependencies: true  # install packages the role needs to run
+gxadmin_manage_apt_cache: true  # update APT cache if outdated
+gxadmin_apt_cache_valid_time: 604800  # time the APT cache is considered valid

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,5 +6,3 @@ gxadmin_create_bin_dir: true
 gxadmin_repo: "https://github.com/galaxyproject/gxadmin.git"
 
 gxadmin_manage_dependencies: true  # install packages the role needs to run
-gxadmin_manage_apt_cache: true  # update APT cache if outdated
-gxadmin_apt_cache_valid_time: 604800  # time the APT cache is considered valid

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,35 @@
 ---
+- name: Update apt cache (Debian derivatives)
+  become: true
+  ansible.builtin.apt:
+    cache_valid_time: "{{ gxadmin_apt_cache_valid_time }}"
+  when: >-
+    ansible_os_family == "Debian"
+    and gxadmin_manage_dependencies
+    and gxadmin_manage_apt_cache
+
+- name: Ensure role and gxadmin dependencies are installed
+  become: true
+  ansible.builtin.package:
+    name:
+      - git
+      - make
+    state: present
+  when: gxadmin_manage_dependencies
+
+- name: Ensure role and gxadmin dependencies are installed (EL)
+  become: true
+  ansible.builtin.package:
+    name: postgresql
+    state: present
+  when: ansible_os_family == "RedHat" and gxadmin_manage_dependencies
+
+- name: Ensure role and gxadmin dependencies are installed (Debian derivatives)
+  become: true
+  ansible.builtin.package:
+    name: postgresql-client
+    state: present
+  when: ansible_os_family == "Debian" and gxadmin_manage_dependencies
 
 - name: Clone gxadmin repository
   ansible.builtin.git:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,22 +13,9 @@
     name:
       - git
       - make
+      - "postgresql{{ '-client' if ansible_os_family == 'Debian' }}"
     state: present
   when: gxadmin_manage_dependencies
-
-- name: Ensure role and gxadmin dependencies are installed (EL)
-  become: true
-  ansible.builtin.package:
-    name: postgresql
-    state: present
-  when: ansible_os_family == "RedHat" and gxadmin_manage_dependencies
-
-- name: Ensure role and gxadmin dependencies are installed (Debian derivatives)
-  become: true
-  ansible.builtin.package:
-    name: postgresql-client
-    state: present
-  when: ansible_os_family == "Debian" and gxadmin_manage_dependencies
 
 - name: Clone gxadmin repository
   ansible.builtin.git:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,11 +2,10 @@
 - name: Update apt cache (Debian derivatives)
   become: true
   ansible.builtin.apt:
-    cache_valid_time: "{{ gxadmin_apt_cache_valid_time }}"
+    cache_valid_time: 604800
   when: >-
     ansible_os_family == "Debian"
     and gxadmin_manage_dependencies
-    and gxadmin_manage_apt_cache
 
 - name: Ensure role and gxadmin dependencies are installed
   become: true


### PR DESCRIPTION
Add tasks that invoke the system's package manager to install all packages the role needs to run.

From my experience as a Galaxy admin, I would say I'd rather have the roles install the packages they need to run rather than having to install them separately the hard way by discovering which ones are missing by trial and error. After all, I am forced to install them anyways.

I have added a couple of boolean role variables to disable this behavior (for edge cases).

I think it makes sense to request a review both from @hexylena and from admins the other main Galaxy instances (@natefoo, @cat-bro) since this is an important role for all of us and I might have missed something when considering what may go wrong.

I have tested this with #10.