### PR TITLE
Fix branch name in Molecule GitHub Actions workflow

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -4,7 +4,7 @@ name: Ansible Molecule
 "on":
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
Run workflow on push to `main` (the default branch of the repository) instead of `master`.